### PR TITLE
Change default ctftime url to the correct ctftime.org

### DIFF
--- a/psybot/config.py
+++ b/psybot/config.py
@@ -30,7 +30,7 @@ class Config:
         self.mongodb_uri = parse_variable("MONGODB_URI", str, default="mongodb://localhost:27017")
         self.mongodb_db = parse_variable("MONGODB_DB", str, default="psybot")
         self.backups_dir = parse_variable("BACKUPS_DIR", str, default=BACKUPS_DIR_DEFAULT)
-        self.ctftime_url = parse_variable("CTFTIME_URL", str, default="https://ctftime.com")
+        self.ctftime_url = parse_variable("CTFTIME_URL", str, default="https://ctftime.org")
 
 
 config = Config()


### PR DESCRIPTION
ctftime.com isn't up and behaves weird on https. I don't think it ever was related to ctftime.org.

```
➜  ~ curl https://ctftime.com
curl: (35) TLS connect error: error:0A000410:SSL routines::ssl/tls alert handshake failure
```